### PR TITLE
Add museum map data importer and map configuration

### DIFF
--- a/src/main/resources/Maps/MapTesting/Museums/Code/DataImporter.xml
+++ b/src/main/resources/Maps/MapTesting/Museums/Code/DataImporter.xml
@@ -1,0 +1,108 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="Maps.MapTesting.Museums.Code.DataImporter" locale="">
+  <web>Maps.MapTesting.Museums.Code</web>
+  <name>DataImporter</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>Data Importer</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content>{{velocity}}
+
+{{info}}
+This page allows to import museum data from Wikidata into the wiki, with the following information for each museum: name, country, coordinates.
+* Step 1: head to https://query.wikidata.org/ and enter the SPARQL query below in the input field:
+
+  {{code}}
+SELECT ?item ?itemLabel ?coord ?lon ?lat ?country ?countryLabel
+WHERE
+{
+ ?item wdt:P17 ?country.
+ ?item wdt:P31 wd:Q33506.   # is a museum
+ ?item p:P625 ?coordinate.
+ ?coordinate ps:P625 ?coord.
+ ?coordinate psv:P625 ?coordinate_node.
+ ?coordinate_node wikibase:geoLongitude ?lon.
+ ?coordinate_node wikibase:geoLatitude ?lat.
+ SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+} limit 100
+  {{/code}}
+
+* Step 2: download the result as a file "data.json" and attach this file to this page.
+* Step 3: hit the "Import data" button below.
+
+{{html}}
+&lt;form action="" method="post"&gt;
+&lt;button type="submit" name="action" value="import"&gt;Import museum data&lt;/button&gt;
+&lt;button type="submit" name="action" value="delete"&gt;Delete all museum pages&lt;/button&gt;
+&lt;/form&gt;
+
+{{/html}}
+{{/info}}
+
+#set ($POINT_CLASS_NAME = 'Maps.Code.PointClass')
+#set ($MUSEUM_CLASS_NAME = 'Maps.MapTesting.Museums.Code.MuseumClass')
+
+#if ($request.action == 'import')
+  #set ($dataAttachment = $doc.getAttachment('data.json'))
+  #set ($json = $dataAttachment.getContentAsString())
+  #set ($data = $jsontool.parse($json))
+  #set ($counter = 0)
+  #foreach ($item in $data)
+    #if ($counter &lt; 100)
+      #set ($itemLabel = $item.itemLabel)
+      #if (!$itemLabel.matches('^Q\d*$'))
+        #set ($counter = $counter + 1)
+        #set ($reference = $services.model.createDocumentReference("", "", $itemLabel))
+        #set ($page = $xwiki.getDocument($reference))
+        #set ($museum = $page.getObject($MUSEUM_CLASS_NAME))
+        #if (!$museum)
+          #set ($museum = $page.newObject($MUSEUM_CLASS_NAME))
+          #set ($point = $page.newObject($POINT_CLASS_NAME))
+          #set ($discard = $museum.set('country', $item.countryLabel))
+          #set ($discard = $point.set('location', "${item.lat},${item.lon}"))
+          #set ($discard = $page.save())
+          * [[$page.fullName]]
+        #end
+      #end
+    #end
+  #end
+#elseif ($request.action == "delete")
+  #set ($hql = "select obj.name from BaseObject as obj where obj.className = :className")
+  #set ($entries = $services.query.hql($hql).bindValue('className', $MUSEUM_CLASS_NAME).execute())
+  #foreach ($entry in $entries)
+    $xwiki.getDocument($entry).delete()
+  #end
+#end
+
+{{/velocity}}</content>
+</xwikidoc>

--- a/src/main/resources/Maps/MapTesting/Museums/Code/MuseumClass.xml
+++ b/src/main/resources/Maps/MapTesting/Museums/Code/MuseumClass.xml
@@ -1,0 +1,64 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="Maps.MapTesting.Museums.Code.MuseumClass" locale="">
+  <web>Maps.MapTesting.Museums.Code</web>
+  <name>MuseumClass</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content/>
+  <class>
+    <name>Maps.MapTesting.Museums.Code.MuseumClass</name>
+    <customClass/>
+    <customMapping/>
+    <defaultViewSheet/>
+    <defaultEditSheet/>
+    <defaultWeb/>
+    <nameField/>
+    <validationScript/>
+    <country>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint/>
+      <name>country</name>
+      <number>1</number>
+      <picker>1</picker>
+      <prettyName>country</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </country>
+  </class>
+</xwikidoc>

--- a/src/main/resources/Maps/MapTesting/Museums/Map.xml
+++ b/src/main/resources/Maps/MapTesting/Museums/Map.xml
@@ -1,0 +1,163 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="Maps.MapTesting.Museums.Map" locale="">
+  <web>Maps.MapTesting.Museums</web>
+  <name>Map</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>World Museums Map</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content/>
+  <object>
+    <name>Maps.MapTesting.Museums.Map</name>
+    <number>0</number>
+    <className>Maps.Code.MapClass</className>
+    <guid>13a538a6-418e-4702-82ce-a0565443f828</guid>
+    <class>
+      <name>Maps.Code.MapClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultLocation>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint>Location to which the map will open to</hint>
+        <name>defaultLocation</name>
+        <number>6</number>
+        <picker>0</picker>
+        <prettyName>Default Location</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultLocation>
+      <defaultZoom>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint>The zoom which the map will open to</hint>
+        <name>defaultZoom</name>
+        <number>1</number>
+        <numberType>integer</numberType>
+        <prettyName>Default Zoom</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </defaultZoom>
+      <includeCurrentLocation>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayFormType>checkbox</displayFormType>
+        <displayType/>
+        <hint/>
+        <name>includeCurrentLocation</name>
+        <number>4</number>
+        <prettyName>Include Current Location</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </includeCurrentLocation>
+      <includeSearch>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayFormType>checkbox</displayFormType>
+        <displayType/>
+        <hint/>
+        <name>includeSearch</name>
+        <number>3</number>
+        <prettyName>Include Search</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </includeSearch>
+      <query>
+        <contenttype>PureText</contenttype>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <hint>Solr query to get data for the map</hint>
+        <name>query</name>
+        <number>6</number>
+        <picker>0</picker>
+        <prettyName>Query</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </query>
+      <tiles>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint>The background tiles</hint>
+        <name>tiles</name>
+        <number>2</number>
+        <picker>0</picker>
+        <prettyName>Tiles</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </tiles>
+    </class>
+    <property>
+      <defaultLocation/>
+    </property>
+    <property>
+      <defaultZoom>14</defaultZoom>
+    </property>
+    <property>
+      <includeCurrentLocation>0</includeCurrentLocation>
+    </property>
+    <property>
+      <includeSearch>1</includeSearch>
+    </property>
+    <property>
+      <query>spaces:Museums</query>
+    </property>
+    <property>
+      <tiles>https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png</tiles>
+    </property>
+  </object>
+</xwikidoc>

--- a/src/main/resources/Maps/MapTesting/Museums/WebHome.xml
+++ b/src/main/resources/Maps/MapTesting/Museums/WebHome.xml
@@ -1,0 +1,43 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.3" reference="Maps.MapTesting.Museums.WebHome" locale="">
+  <web>Maps.MapTesting.Museums</web>
+  <name>WebHome</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>Museums</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content>
+
+* [[World Museums Map&gt;&gt;Map]]
+* [[World Museums Data Importer&gt;&gt;.Code.DataImporter]]</content>
+</xwikidoc>


### PR DESCRIPTION
This pull request adds a museum data importer script to the testing area and a sample map configuration. In order to configure this map facet with the current code, add the following to the top of CommonMacros: 

```
{{velocity output="false"}}
#set ($solrConfig = {
  'filterQuery': [
    'type:DOCUMENT',
    'class:Maps.Code.PointClass'
  ],
  'facetFields': [
    'property.Maps.MapTesting.Museums.Code.MuseumClass.country_string'
  ]
})
{{/velocity}}
```

Head to page "Maps.MapTesting.Museums.WebHome" and follow the data importer instructions to import sample data.