### PR TITLE
[Misc] Updated the method to call init() using newer XWiki API

### DIFF
--- a/application-interactive-maps-ui/src/main/resources/Maps/Code/MapSheet.xml
+++ b/application-interactive-maps-ui/src/main/resources/Maps/Code/MapSheet.xml
@@ -191,7 +191,7 @@
       <code>//Make sure to include Maps.Code.LeafletUtils before using this
 require(['jquery', 'leaflet', 'leaflet-commons', 'leaflet-indoor', 'bootstrap'], function ($, leaflet, leafletCommons) {
   'use strict';
-  function init()
+  var init = function ()
   {
 
     var map;
@@ -459,12 +459,8 @@ require(['jquery', 'leaflet', 'leaflet-commons', 'leaflet-indoor', 'bootstrap'],
       $('.map-search-filter').removeClass('open');
       leafletCommons.updateURLWithMapState();
     });
-
+    $(init).on('xwiki:dom:updated', init);
   }
-
-  //Run the init() function when dom is loaded or updated
-  (XWiki &amp;&amp; XWiki.domIsLoaded &amp;&amp; init()) || document.observe("xwiki:dom:loaded", init);
-  (XWiki &amp;&amp; XWiki.domIsUpdated &amp;&amp; init()) || document.observe("xwiki:dom:updated", init);
 
 });</code>
     </property>


### PR DESCRIPTION
This PR doesn't change anything except for using a shorter method to first check for DOM loaded and then for DOM updated.
Idea credits: @mflorea 

This calls init:

- first when DOM is ready:  `$(init)`
- then each time DOM is updated:  `.on('xwiki:dom:updated', init);`

Similar usecase: https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-war/src/main/webapp/resources/uicomponents/widgets/tree.js#L32

See: https://api.jquery.com/jquery/#jQuery3